### PR TITLE
fix up the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@
 FROM --platform=$TARGETPLATFORM alpine:3.13
 
 RUN apk add --no-cache ca-certificates
-ADD rackspace-cloud-controller-manager /bin/rackspace-cloud-controller-manager
+ADD rackspace-cloud-controller-manager /bin/cloud-controller-manager
+
+ENTRYPOINT ["/bin/cloud-controller-manager"]

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test: fmtcheck
 	go test $(TEST)
 
 build: fmtcheck
-	GCO_ENABLED=0 go build \
+	GCO_ENABLED=0 GOOS=linux go build \
 		-ldflags $(LDFLAGS) \
 		-o $(TARGET) \
 		cmd/openstack-cloud-controller-manager/main.go


### PR DESCRIPTION
We need to set the entry point for the Docker container and ensure we are targeting Linux when we build.