### PR TITLE
support multiple ports per service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
-	github.com/os-pc/gocloudlb v0.0.0-20210518234701-90577a315448 // indirect
+	github.com/os-pc/gocloudlb v0.0.0-20210529010120-65b17b6d1ffa // indirect
 	github.com/pborman/uuid v1.2.0
 	github.com/prometheus/client_golang v1.4.1
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -651,6 +651,10 @@ github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52 h1:B8hYj3
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/os-pc/gocloudlb v0.0.0-20210518234701-90577a315448 h1:VKKkMiR7ZTMlovbkPicjt1VOhaVS8paCBgy1Y/Eu9sE=
 github.com/os-pc/gocloudlb v0.0.0-20210518234701-90577a315448/go.mod h1:vCN4JD8GTX/YkdqM3FVBtGBuHwJdC8ZRcJJHllq6qas=
+github.com/os-pc/gocloudlb v0.0.0-20210528174209-d5dae696eacd h1:1S53AdBVsM+EGzzGyuEo+S2RjKmdaY+wovkoYeVqx50=
+github.com/os-pc/gocloudlb v0.0.0-20210528174209-d5dae696eacd/go.mod h1:vCN4JD8GTX/YkdqM3FVBtGBuHwJdC8ZRcJJHllq6qas=
+github.com/os-pc/gocloudlb v0.0.0-20210529010120-65b17b6d1ffa h1:1AqEZeYDKWyZrjAAeE8bM7jQnhSnXA9IWHXpAxzgeD0=
+github.com/os-pc/gocloudlb v0.0.0-20210529010120-65b17b6d1ffa/go.mod h1:vCN4JD8GTX/YkdqM3FVBtGBuHwJdC8ZRcJJHllq6qas=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -149,7 +149,11 @@ func waitLoadbalancerActiveStatus(client *gophercloud.ServiceClient, loadbalance
 	var provisioningStatus string
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		loadbalancer, err := loadbalancers.Get(client, loadbalancerID).Extract()
-		if err != nil {
+		if err != nil && cpoerrors.IsPendingUpdate(err) {
+			klog.V(6).Infof("LoadBalancer %d: Waiting for status %s but got HTTP %v",
+				loadbalancerID, activeStatus, err)
+			return false, nil
+		} else if err != nil {
 			return false, err
 		}
 

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -438,10 +438,14 @@ func (lbaas *CloudLb) ensureLoadBalancerNodes(lbID uint64, port corev1.ServicePo
 		}
 	}
 
-	klog.V(4).Infof("Adding nodes to load balancer %d", lbID)
-	_, createErr := lbnodes.Create(lbaas.lb, lbID, addNodes).Extract()
-	if createErr != nil {
-		return fmt.Errorf("error adding nodes to load balancer: %d, %v", lbID, createErr)
+	if len(addNodes) > 0 {
+		klog.V(4).Infof("Adding nodes to load balancer %d", lbID)
+		_, createErr := lbnodes.Create(lbaas.lb, lbID, addNodes).Extract()
+		if createErr != nil {
+			return fmt.Errorf("error adding nodes to load balancer: %d, %v", lbID, createErr)
+		}
+	} else {
+		klog.V(4).Infof("No nodes need to be added to load balancer %d", lbID)
 	}
 
 	provisioningStatus, err := waitLoadbalancerActiveStatus(lbaas.lb, lbID)

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -39,3 +39,13 @@ func IsNotFound(err error) bool {
 
 	return false
 }
+
+func IsPendingUpdate(err error) bool {
+	if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
+		if errCode.Actual == http.StatusUnprocessableEntity {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Cloud Load Balancers support one port per load balancer so we must make multiple Cloud Load Balancers that share VIPs so achieve a service with multiple ports. To achieve this we use the fact that load balancers do not have to be uniquely named so we name all load balancers for a service the same thing and then look up the correct one by port number.

Fixed other issues along the way:
- some pending changes on a Cloud Load Balancer return a 422 instead of a 200 with a status of PENDING_UPDATE
- delete API returns a 201 with no JSON body
- checking the status of a deleted load balancer returns a 200 instead of a 404 with a status of DELETED
- only attempt to add nodes to a load balancer when the node list has changed