### PR TITLE
simplify Rackspace API key auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,3 +54,5 @@ replace (
 	k8s.io/metrics => k8s.io/metrics v0.18.0
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.18.0
 )
+
+replace github.com/gophercloud/gophercloud v1.4.0 => github.com/cardoe/gophercloud v0.12.1-0.20230622192811-3a9395130c0b

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/caddyserver/caddy v1.0.3/go.mod h1:G+ouvOY32gENkJC+jhgl62TyhvqEsFaDiZ4uw0RzP1E=
+github.com/cardoe/gophercloud v0.12.1-0.20230622192811-3a9395130c0b h1:+J6QF6IWR6DZ0QRsIR4/WNXpr0di/w2WY2TxP2QpHws=
+github.com/cardoe/gophercloud v0.12.1-0.20230622192811-3a9395130c0b/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/prettybench v0.0.0-20150116022406-03b8cfe5406c/go.mod h1:Xe6ZsFhtM8HrDku0pxJ3/Lr51rwykrzgFwpmTzleatY=
@@ -283,8 +285,6 @@ github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTV
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.7.0/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
 github.com/gophercloud/gophercloud v1.3.0/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
-github.com/gophercloud/gophercloud v1.4.0 h1:RqEu43vaX0lb0LanZr5BylK5ICVxjpFFoc0sxivyuHU=
-github.com/gophercloud/gophercloud v1.4.0/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
 github.com/gophercloud/utils v0.0.0-20230523080330-de873b9cf00d h1:6Gvua77nKyAiZQpu0N3AsamGu1L6Mlnhp3tAtDcqwvc=
 github.com/gophercloud/utils v0.0.0-20230523080330-de873b9cf00d/go.mod h1:VSalo4adEk+3sNkmVJLnhHoOyOYYS8sTWLG4mv5BKto=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=

--- a/pkg/util/raxauth/auth_options.go
+++ b/pkg/util/raxauth/auth_options.go
@@ -3,121 +3,37 @@ package raxauth
 import (
 	"fmt"
 
-	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack"
 	tokens2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
 )
 
-// ApiKeyCredentialsV2 represents the required options to authenticate
-// with a Rackspace API key
-type ApiKeyCredentialsV2 struct {
-	Username string `json:"username" required:"true"`
-	ApiKey   string `json:"apiKey" required:"true"`
-}
-
 // AuthOptions are the valid options for Openstack Identity v2 authentication.
 // For field descriptions, see gophercloud.AuthOptions.
-type AuthOptions struct {
-	IdentityEndpoint string `json:"-"`
-	Username         string `json:"username,omitempty"`
-	Password         string `json:"password,omitempty"`
-	ApiKey           string `json:"apiKey,omitempty"`
-	TenantID         string `json:"tenantId,omitempty"`
-	TenantName       string `json:"tenantName,omitempty"`
-	AllowReauth      bool   `json:"-"`
-	TokenID          string
-}
-
-// AuthOptionsV2 wraps a gophercloud AuthOptions in order to adhere to the
-// AuthOptionsBuilder interface.
-type AuthOptionsV2 struct {
-	PasswordCredentials *tokens2.PasswordCredentialsV2 `json:"passwordCredentials,omitempty"`
-
-	// TokenCredentials allows users to authenticate (possibly as another user)
-	// with an authentication token ID.
-	TokenCredentials *tokens2.TokenCredentialsV2 `json:"token,omitempty"`
-
-	// ApiKeyCredentials allows users to authenticate with a Rackspace API key
-	ApiKeyCredentials *ApiKeyCredentialsV2 `json:"RAX-KSKEY:apiKeyCredentials,omitempty"`
+type AuthOptionsRax struct {
+	tokens2.AuthOptions
+	ApiKey string `json:"apiKey,omitempty"`
 }
 
 // ToTokenV2CreateMap allows AuthOptions to satisfy the AuthOptionsBuilder
 // interface in the v2 tokens package
-func (opts AuthOptions) ToTokenV2CreateMap() (map[string]interface{}, error) {
-	// Populate the request map.
-	v2Opts := AuthOptionsV2{}
+func (opts AuthOptionsRax) ToTokenV2CreateMap() (map[string]interface{}, error) {
 
+	// if we have an ApiKey, use that otherwise just use the regular auth mechanism
 	if opts.ApiKey != "" {
 		if opts.Username == "" {
 			return nil, fmt.Errorf("username must be supplied for API key auth")
 		}
-		v2Opts.ApiKeyCredentials = &ApiKeyCredentialsV2{
-			Username: opts.Username,
-			ApiKey:   opts.ApiKey,
-		}
-	} else if opts.Password != "" {
-		if opts.Username == "" {
-			return nil, fmt.Errorf("username must be supplied for password auth")
-		}
-		v2Opts.PasswordCredentials = &tokens2.PasswordCredentialsV2{
-			Username: opts.Username,
-			Password: opts.Password,
-		}
-	} else if opts.TokenID != "" {
-		v2Opts.TokenCredentials = &tokens2.TokenCredentialsV2{
-			ID: opts.TokenID,
-		}
+
+		return map[string]interface{}{
+			"auth": map[string]interface{}{
+				"RAX-KSKEY:apiKeyCredentials": map[string]interface{}{
+					"username": opts.AuthOptions.Username,
+					"apiKey":   opts.ApiKey,
+				},
+			},
+		}, nil
+	} else if opts.AuthOptions.Username != "" || opts.AuthOptions.TokenID != "" {
+		return opts.AuthOptions.ToTokenV2CreateMap()
 	} else {
 		return nil, fmt.Errorf("missing username/password/apiKey or tokenId for auth")
 	}
-
-	b, err := gophercloud.BuildRequestBody(v2Opts, "auth")
-	if err != nil {
-		return nil, fmt.Errorf("unable to create auth request: %v", err)
-	}
-	return b, nil
-}
-
-func Authenticate(client *gophercloud.ProviderClient, options AuthOptions, eo gophercloud.EndpointOpts) error {
-	v2Client, err := openstack.NewIdentityV2(client, eo)
-	if err != nil {
-		return err
-	}
-
-	result := tokens2.Create(v2Client, options)
-
-	err = client.SetTokenAndAuthResult(result)
-	if err != nil {
-		return err
-	}
-
-	catalog, err := result.ExtractServiceCatalog()
-	if err != nil {
-		return err
-	}
-
-	if options.AllowReauth {
-		// here we're creating a throw-away client (tac). it's a copy of the user's provider client, but
-		// with the token and reauth func zeroed out. combined with setting `AllowReauth` to `false`,
-		// this should retry authentication only once
-		tac := *client
-		tac.SetThrowaway(true)
-		tac.ReauthFunc = nil
-		tac.SetTokenAndAuthResult(nil)
-		tao := options
-		tao.AllowReauth = false
-		client.ReauthFunc = func() error {
-			err := Authenticate(&tac, tao, eo)
-			if err != nil {
-				return err
-			}
-			client.CopyTokenFrom(&tac)
-			return nil
-		}
-	}
-	client.EndpointLocator = func(opts gophercloud.EndpointOpts) (string, error) {
-		return openstack.V2EndpointURL(catalog, opts)
-	}
-
-	return nil
 }


### PR DESCRIPTION
Taking advantage of gophercloud/gophercloud#2655, simplify how we can implement Rackspace API key authentication. This allows us to implement just the Rackspace specific bits out of tree but utilize the rest of gophercloud for all other authentication mechanisms.